### PR TITLE
Fix build with musl libc

### DIFF
--- a/utf8.h
+++ b/utf8.h
@@ -27,13 +27,17 @@
 #define UTF8_IGNORE_ERROR		0x01
 #define UTF8_SKIP_BOM			0x02
 
-__BEGIN_DECLS
+#ifdef   __cplusplus
+extern "C" {
+#endif
 
 size_t		utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 		    size_t outsize, int flags);
 size_t		wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
 		    size_t outsize, int flags);
 
-__END_DECLS
+#ifdef   __cplusplus
+}
+#endif
 
 #endif /* !_UTF8_H_ */


### PR DESCRIPTION
Avoid using the glibc internal macros __BEGIN/__END_DECLS.

Signed-off-by: Natanael Copa ncopa@alpinelinux.org
