### PR TITLE
drop pointless __unix__ guard

### DIFF
--- a/figlet.c
+++ b/figlet.c
@@ -65,9 +65,9 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <fcntl.h>     /* Needed for get_columns */
-
-#if defined(unix) || defined(__unix__) || defined(__APPLE__)
 #include <unistd.h>
+
+#ifndef _WIN32
 #include <sys/ioctl.h> /* Needed for get_columns */
 #endif
 


### PR DESCRIPTION
drop __unix__ guard in favor of not including headers on platforms without said headers.