### PR TITLE
Showfigfont fix fonts with spaces

### DIFF
--- a/showfigfonts
+++ b/showfigfonts
@@ -43,8 +43,9 @@ else
   fi
 fi
 
-FONTLIST=`ls "$FONTDIR"/*.flf | sed 's!.*/\(.*\)\.flf$!\1!'`
-for F in $FONTLIST ; do
+for F in "$FONTDIR"/*.flf ; do
+  F=${F##*/}
+  F=${F%.flf}
   echo "$F :"
   if [ -n "$WORD" ]; then
     echo "$WORD" | $FIGLET -d "$FONTDIR" -f "$F"


### PR DESCRIPTION
Before that fonts with filename containing spaces, such as
"ANSI Regular.flf" would error out:
```
figlet: ANSI: Unable to open font file
figlet: Regular: Unable to open font file
```